### PR TITLE
Add test.sh and some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 tmp*
 9cc
 a.out
+test/exec/*.bin
+test/exec/*.gccbin
+test/exec/*.output
+test/exec/*.diff
+test/exec/*.s

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ test: 9cc test/test.c
 	@gcc -static -o tmp-test tmp-test.s tmp-test2.o
 	@./tmp-test
 
-clean:
-	rm -f 9cc *.o *~ tmp* a.out test/*~
+slow-tests: 9cc test
+	./test/test.sh
 
-.PHONY: test clean
+clean:
+	rm -f 9cc *.o *~ tmp* a.out test/*~ test/exec/*.{gccbin,bin,expected,s,output,diff}
+
+.PHONY: test slow-tests clean

--- a/test/exec/0001-sanity.c
+++ b/test/exec/0001-sanity.c
@@ -1,0 +1,5 @@
+int
+main()
+{
+	return 0;
+}

--- a/test/exec/0002-global.c
+++ b/test/exec/0002-global.c
@@ -1,0 +1,8 @@
+int x;
+
+int
+main()
+{
+	x = 0;
+	return x;
+}

--- a/test/exec/0003-nqueen.c
+++ b/test/exec/0003-nqueen.c
@@ -1,0 +1,48 @@
+
+int print_board(int *board) {
+  for (int i = 0; i < 10; i=i+1) {
+    for (int j = 0; j < 10; j=j+1)
+      if (board[i * 10 + j])
+	printf("Q ");
+      else
+	printf(". ");
+    printf("\n");
+  }
+  printf("\n\n");
+}
+
+int conflict(int *board, int row, int col) {
+  for (int i = 0; i < row; i=i+1) {
+    if (board[i * 10 + col])
+      return 1;
+    int j = row - i;
+    if (0 < col - j + 1 && board[i * 10 + col - j])
+      return 1;
+    if (col + j < 10 && board[i * 10 + col + j])
+      return 1;
+  }
+  return 0;
+}
+
+int solve(int *board, int row) {
+  if (row > 9) {
+    print_board(board);
+    return 0;
+  }
+  for (int i = 0; i < 10; i=i+1) {
+    if (conflict(board, row, i)) {
+    } else {
+      board[row * 10 + i] = 1;
+      solve(board, row + 1);
+      board[row * 10 + i] = 0;
+    }
+  }
+}
+
+int main() {
+  int board[100];
+  for (int i = 0; i < 100; i=i+1)
+    board[i] = 0;
+  solve(board, 0);
+  return 0;
+}

--- a/test/exec/0004-operators.c
+++ b/test/exec/0004-operators.c
@@ -1,0 +1,46 @@
+
+int g;
+
+int
+effect()
+{
+	g = 1;
+	return 1;
+}
+
+int
+main()
+{
+    int x;
+    
+    g = 0;
+    x = 0;
+    if(x && effect())
+    	return 1;
+    if(g)
+    	return 2;
+    x = 1;
+    if(x && effect()) {
+    	if(g != 1)
+    		return 3;
+    } else {
+    	return 4;
+    }
+    g = 0;
+    x = 1;
+    if(x || effect()) {
+    	if(g)
+    		return 5;
+    } else {
+    	return 6;
+    }
+    x = 0;
+    if(x || effect()) {
+    	if(g != 1)
+    		return 7;
+    } else {
+    	return 8;
+    } 
+    return 0;
+}
+

--- a/test/exec/0005-operators.c
+++ b/test/exec/0005-operators.c
@@ -1,0 +1,56 @@
+/* TODO: more types */
+
+int
+main()
+{
+	int x;
+
+	x = 0;
+	x = x + 2;        // 2
+	x = x - 1;        // 1
+	x = x * 6;        // 6
+	x = x / 2;        // 3
+	x = x % 2;        // 1
+	x = x << 2;       // 4
+	x = x >> 1;       // 2
+	x = x | 255;      // 255
+	x = x & 3;        // 3
+	x = x ^ 1;        // 2
+	if(x != 2)
+		return 1;
+	if(!(x == 2))
+		return 2;
+	if(x == 3)
+		return 3;
+	if(x != 2)
+		return 4;
+	if(!(x != 3))
+		return 5;
+	if(x < 1)
+		return 6;
+	if(x < 2)
+		return 7;
+	if(!(x < 3))
+		return 8;
+	if(!(x > 1))
+		return 9;
+	if(x > 2)
+		return 10;
+	if(x > 3)
+		return 11;
+	if(x <= 1)
+		return 12;
+	if(!(x <= 2))
+		return 13;
+	if(!(x <= 3))
+		return 14;
+	if(!(x >= 1))
+		return 15;
+	if(!(x >= 2))
+		return 16;
+	if(x >= 3)
+		return 17;
+	return 0;
+
+}
+

--- a/test/exec/0006-if.c
+++ b/test/exec/0006-if.c
@@ -1,0 +1,20 @@
+int
+main()
+{
+	if(0) {
+		return 1;
+	} else if(0) {
+		/* empty */	
+	} else {
+		if(1) {
+			if(0)
+				return 1;
+			else
+				return 0;
+		} else {
+			return 1;
+		}
+	}
+	return 1;
+}
+

--- a/test/exec/0007-dowhile.c
+++ b/test/exec/0007-dowhile.c
@@ -1,0 +1,17 @@
+int 
+main()
+{
+	int x;
+	
+	x = 0;
+	do 
+	  x = x + 1;
+	while(x < 10);
+	
+	do {
+	  x = x + 1;
+	} while(x < 20);
+	
+	return x - 20;
+}
+

--- a/test/exec/0008-while.c
+++ b/test/exec/0008-while.c
@@ -1,0 +1,10 @@
+int
+main()
+{
+	int x;
+	
+	x = 10;
+	while(x)
+		x = x - 1;
+	return x;
+}

--- a/test/exec/0009-for.c
+++ b/test/exec/0009-for.c
@@ -1,0 +1,12 @@
+int 
+main()
+{
+	int x;
+	
+	for(x = 0; x < 10 ; x = x + 1)
+		;
+	if(x != 10)
+		return 1;
+	return 0;
+}
+

--- a/test/exec/0010-pointers.c
+++ b/test/exec/0010-pointers.c
@@ -1,0 +1,21 @@
+int g;
+
+int
+main()
+{
+	int  x;
+	int *p;
+
+	g = 1;
+	x = 1;
+	p = &x;
+	*p = 0;
+	if(x)
+		return 1;
+	
+	p = &g;
+	*p = 0;
+	if(g)
+		return 1;
+	return 0;
+}

--- a/test/exec/0011-pointers.c
+++ b/test/exec/0011-pointers.c
@@ -1,0 +1,13 @@
+int
+main()
+{
+	int   x;
+	int  *p;
+	int **pp;
+	
+	x = 1;
+	p = &x;
+	pp = &p;
+	**pp = 0;
+	return x;
+}

--- a/test/exec/0012-array.c
+++ b/test/exec/0012-array.c
@@ -1,0 +1,11 @@
+int
+main()
+{
+	int arr[2];
+	
+	arr[1] = 2;
+	if(arr[1] != 2)
+		return 1;
+	return 0;
+}
+

--- a/test/exec/0013-calls.c
+++ b/test/exec/0013-calls.c
@@ -1,0 +1,12 @@
+
+int 
+foo()
+{
+    return 0;
+}
+
+int 
+main()
+{
+    return foo();
+}

--- a/test/exec/0014-calls.c
+++ b/test/exec/0014-calls.c
@@ -1,0 +1,12 @@
+
+int
+foo(int a, int b)
+{
+    return a + b;
+}
+
+int
+main()
+{
+    return foo(1, 2) - 3;
+}

--- a/test/exec/0015-calls.c
+++ b/test/exec/0015-calls.c
@@ -1,0 +1,16 @@
+int x;
+
+int
+foo(int *p1)
+{
+    *p1 = 0;
+    return 0;
+}
+
+int
+main()
+{
+    x = 6;
+    foo(&x);
+    return x;
+}

--- a/test/exec/0016-string.c
+++ b/test/exec/0016-string.c
@@ -1,0 +1,12 @@
+int
+main()
+{
+	char *p;
+
+	p = "foobar";
+	if(p[1] != 111)
+		return 1;
+	if(p[6] != 0)
+		return 1;
+	return 0;
+}

--- a/test/exec/0017-incdec.c
+++ b/test/exec/0017-incdec.c
@@ -1,0 +1,24 @@
+int
+main()
+{
+	int x;
+	
+	x = 0;
+	if(x++)
+		return 1;
+	if(x != 1)
+		return 2;
+	if(++x != 2)
+		return 3;
+	if(x != 2)
+		return 4;
+	if(--x != 1)
+		return 5;
+	if(x != 1)
+		return 6;
+	if(x-- != 1)
+		return 7;
+	if(x != 0)
+		return 8;
+	return 0;
+}

--- a/test/exec/0018-condexpr.c
+++ b/test/exec/0018-condexpr.c
@@ -1,0 +1,11 @@
+int
+main()
+{
+	int x;
+
+	x = 0;
+	x = x ? 0 : 2;
+	if(x != 2)
+		return 1;
+	return x == 2 ? 0 : 1;
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,98 @@
+#! /bin/sh
+
+set -e
+set -u
+
+if ! test -f README.md
+then
+    echo "run from the 9cc base directory." >&2
+    exit 1
+fi
+
+if ! test -f ./9cc
+then
+    echo "please build 9cc first." >&2
+    exit 1
+fi
+
+run9cc="./9cc"
+if which valgrind > /dev/null
+then
+    # Detect bad memory accesses, but ignore leaks.
+    run9cc="valgrind --leak-check=no --quiet ./9cc"
+else
+     echo "not using valgrind..." >&2
+fi
+
+testcount=0
+passcount=0
+
+# Run an exec test:
+# Check the runs with gcc, save+cache output.
+# Check the test compiles (with valgrind).
+# Check the test assembles.
+# Check the test returns with rc=0.
+# Check the test output matches gcc.
+exectest () {
+    t="$1"
+    echo -n "$t: "
+
+    if ! test -f "$t.expected"
+    then
+        if ! gcc -g -O0 "$t" -o "$t.gccbin" 2>/dev/null
+        then
+            echo "fail(didn't compile with gcc)"
+            return 1
+        fi
+
+        if ! "$t.gccbin" > "$t.expected"
+        then
+            rm "$t.expected"
+            echo "fail(test didn't have rc=0 when built with gcc)"
+            return 1
+        fi
+    fi
+
+    if ! $run9cc "$t" 2> /dev/null > "$t.s"
+    then
+        echo "fail(didn't compile with 9cc)"
+        return 1
+    fi
+
+    if ! gcc -o "$t.bin" "$t.s"
+    then
+        echo "fail(9cc output didn't assemble)"
+        return 1
+    fi
+
+    if ! "$t.bin" > "$t.output"
+    then
+        echo "fail(bad exit rc=$?)"
+        return 1
+    fi
+
+    if ! diff -u "$t.expected" "$t.output" > "$t.diff"
+    then
+        echo "fail(output differs)"
+        cat "$t.diff"
+        return 1
+    fi
+
+    echo "ok"
+}
+
+counttest () {
+    if $1 $2
+    then
+        passcount=$(($passcount+1))
+    fi
+    testcount=$(($testcount+1))
+}
+
+testdir="./test/exec"
+for t in $testdir/*.c
+do
+    counttest exectest $t
+done
+
+echo "$0 passed $passcount/$testcount"


### PR DESCRIPTION
This pull request adds a test.sh script that does a few more checks, and makes it easier to import tests from other compiler projects. The test suite uses valgrind if it is installed to detect memory access bugs, but is configured to ignore memory leaks (indeed I have a test case that causes an invalid memory access).  The tests are named so that they will be run in order.

The tests are run with "make slow-tests"

I took care to keep the test script as simple and clean as I could, giving informative messages
at every failure. Each test is first run with gcc to get the expected stdout output, but then cached.

The test dir is named exec, because in the future we may want tests that don't run, or are intended
to check compiler error messages.

I have prepared a terminal recording here to show you how it looks:

https://asciinema.org/a/8cxzli11HgU57mfqBoHJenssO

I have my own compiler test suite located here - https://github.com/andrewchambers/c/tree/master/test which has some tests that could be imported.

Using diff + gcc would probably also improve the readability of the existing test when it fails, but gcc currently rejects the test code, so I didn't add that improvement.

If using gcc as a reference compiler is too slow for many tests, tcc is a good alternative.

edit: I imported and ordered a bunch of tests that already pass to help with your regression testing. I do not want to add failing tests, because they are demotivation, and its best to focus on one case at a time :)
