### PR TITLE
fix oob

### DIFF
--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ static char *read_file(char *filename) {
     sb_append_n(sb, buf, nread);
   }
 
-  if (sb->data[sb->len] != '\n')
+  if (sb->data[sb->len-1] != '\n')
     sb_add(sb, '\n');
   return sb_get(sb);
 }


### PR DESCRIPTION
Found by https://c-testsuite.github.io/9cc_report.html

```
not ok ./tests/simple-exec/0013-breakcont.c
  int
  main()
  {
  	int x;
  	
  	x = 0;
  	while(1)
  		break;
  	while(1) {
  		if (x == 5) {
  			break;
  		}
  		x = x + 1;
  		continue;
  	}
  	for (;;) {
  		if (x == 10) {
  			break;
  		}
  		x = x + 1;
  		continue;
  	}
  	do {
  		if (x == 15) {
  			break;
  		}
  		x = x + 1;
  		continue;
  	} while(1);
  	return x - 15;
  }
  +valgrind --leak-check=no -q 9cc ./tests/simple-exec/0013-breakcont.c
  ==6171== Conditional jump or move depends on uninitialised value(s)
  ==6171==    at 0x40334D: read_file (main.c:24)
  ==6171==    by 0x4034BE: main (main.c:56)
  ==6171== 
  undefined variable: continue
  +exit 1
```