### PR TITLE
parse.c: initialize lvars earlier to fix seg fault

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -888,6 +888,7 @@ static void toplevel() {
 
   // Function
   if (consume('(')) {
+    lvars = new_vec();
     Vector *params = new_vec();
     while (!consume(')')) {
       if (params->len > 0)
@@ -898,7 +899,6 @@ static void toplevel() {
     Token *t = tokens->data[pos];
     Node *node = new_node(ND_DECL, t);
 
-    lvars = new_vec();
     breaks = new_vec();
     continues = new_vec();
     switches = new_vec();


### PR DESCRIPTION
Fix #11 