### PR TITLE
Fix compiler formater arguments warnings

### DIFF
--- a/token.c
+++ b/token.c
@@ -93,7 +93,7 @@ static void print_line(char *buf, char *path, char *pos) {
 void warn_token(Token *t, char *msg) {
   if (t->start)
     print_line(t->buf, t->path, t->start);
-  fprintf(stderr, msg);
+  fprintf(stderr, "%s", msg);
   fprintf(stderr, "\n");
 }
 
@@ -104,7 +104,7 @@ noreturn void bad_token(Token *t, char *msg) {
 
 noreturn static void bad_position(char *p, char *msg) {
   print_line(env->buf, env->path, p);
-  error(msg);
+  error("%s", msg);
 }
 
 int get_line_number(Token *t) {


### PR DESCRIPTION
Fixing those warnings from GCC (`gcc version 8.2.0 (Ubuntu 8.2.0-7ubuntu1)`):
```c
token.c: In function ‘warn_token’:
token.c:96:3: warning: format not a string literal and no format arguments [-Wformat-security]
   fprintf(stderr, msg);
   ^~~~~~~
token.c: In function ‘bad_position’:
token.c:107:3: warning: format not a string literal and no format arguments [-Wformat-security]
   error(msg);
   ^~~~~
```