### PR TITLE
FIX: core dump while lvars may use before declaration in `param_declaration

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -886,6 +886,11 @@ static void toplevel() {
 
   char *name = ident();
 
+  lvars = new_vec();
+  breaks = new_vec();
+  continues = new_vec();
+  switches = new_vec();
+
   // Function
   if (consume('(')) {
     Vector *params = new_vec();
@@ -897,11 +902,6 @@ static void toplevel() {
 
     Token *t = tokens->data[pos];
     Node *node = new_node(ND_DECL, t);
-
-    lvars = new_vec();
-    breaks = new_vec();
-    continues = new_vec();
-    switches = new_vec();
 
     node->name = name;
     node->params = params;


### PR DESCRIPTION
9cc may core dump while `param_declaration` may use lvars before declaration

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xc)
  * frame #0: 0x000000010000c4e4 9cc`vec_push(v=0x0000000000000000, elem=0x0000000100109670) at util.c:29:10
    frame #1: 0x00000001000052ec 9cc`add_lvar(ty=0x0000000100109630, name="board") at parse.c:81:3
    frame #2: 0x0000000100007f49 9cc`param_declaration at parse.c:717:10
    frame #3: 0x0000000100004f1f 9cc`toplevel at parse.c:895:24
```